### PR TITLE
Feature: raw command with individual sensor readings and zone readings

### DIFF
--- a/firmware/src/board_defs.h
+++ b/firmware/src/board_defs.h
@@ -6,8 +6,8 @@
 #if defined BOARD_MAI_PICO
 
 #define I2C_PORT i2c1
-#define I2C_SDA 16
-#define I2C_SCL 17
+#define I2C_SDA 6
+#define I2C_SCL 7
 #define I2C_FREQ 400*1000
 
 #define RGB_PIN 13

--- a/firmware/src/board_defs.h
+++ b/firmware/src/board_defs.h
@@ -6,8 +6,8 @@
 #if defined BOARD_MAI_PICO
 
 #define I2C_PORT i2c1
-#define I2C_SDA 6
-#define I2C_SCL 7
+#define I2C_SDA 16
+#define I2C_SCL 17
 #define I2C_FREQ 400*1000
 
 #define RGB_PIN 13

--- a/firmware/src/commands.c
+++ b/firmware/src/commands.c
@@ -22,8 +22,6 @@
 #define SENSE_LIMIT_MAX 9
 #define SENSE_LIMIT_MIN -9
 
-static uint8_t touch_map[] = TOUCH_MAP;
-
 static void disp_rgb()
 {
     printf("[RGB]\n");
@@ -408,14 +406,10 @@ static void print_readings(const char *title, const uint16_t *raw, int num)
 
 static void handle_raw()
 {
-    static uint16_t zones[36] = {0};
+    const uint16_t *raw = touch_raw();
+    const uint16_t *zones = map_raw_to_zones(raw);
 
     printf("Touch raw readings:\n");
-    const uint16_t *raw = touch_raw();
-
-    for (int i = 0; i < 34; i++) {
-        zones[touch_map[i]] = raw[i];
-    }
 
     printf("   Sensor: 0: %s, 1: %s 2: %s\n",
             touch_sensor_ok(0) ? "OK" : "ERR",

--- a/firmware/src/commands.c
+++ b/firmware/src/commands.c
@@ -22,6 +22,8 @@
 #define SENSE_LIMIT_MAX 9
 #define SENSE_LIMIT_MIN -9
 
+static uint8_t touch_map[] = TOUCH_MAP;
+
 static void disp_rgb()
 {
     printf("[RGB]\n");
@@ -395,30 +397,44 @@ static void handle_debounce(int argc, char *argv[])
     disp_sense();
 }
 
-static void print_raw_zones(const char *title, const uint16_t *raw, int num)
+static void print_readings(const char *title, const uint16_t *raw, int num)
 {
     printf(" %s |", title);
     for (int i = 0; i < num; i++) {
-        printf(" %3d |", raw[i]);
+        printf(" %4d |", raw[i]);
     }
     printf("\n");
 }
 
 static void handle_raw()
 {
+    static uint16_t zones[36] = {0};
+
     printf("Touch raw readings:\n");
     const uint16_t *raw = touch_raw();
+
+    for (int i = 0; i < 34; i++) {
+        zones[touch_map[i]] = raw[i];
+    }
+
     printf("   Sensor: 0: %s, 1: %s 2: %s\n",
             touch_sensor_ok(0) ? "OK" : "ERR",
             touch_sensor_ok(1) ? "OK" : "ERR",
             touch_sensor_ok(2) ? "OK" : "ERR");
+    
+    printf("   Sensor readings:\n");
+    printf("   |___1__|___2__|___3__|___4__|___5__|___6__|___7__|___8__|___9__|__10__|__11__|__12__|\n");
+    print_readings("0", raw, 12);
+    print_readings("1", raw + 12, 12);
+    print_readings("2", raw + 24, 12);
 
-    printf("   |__1__|__2__|__3__|__4__|__5__|__6__|__7__|__8__|\n");
-    print_raw_zones("A", raw, 8);
-    print_raw_zones("B", raw + 8, 8);
-    print_raw_zones("C", raw + 16, 2);
-    print_raw_zones("D", raw + 18, 8);
-    print_raw_zones("E", raw + 26, 8);
+    printf("   Zone readings:\n");
+    printf("   |___1__|___2__|___3__|___4__|___5__|___6__|___7__|___8__|\n");
+    print_readings("A", zones, 8);
+    print_readings("B", zones + 8, 8);
+    print_readings("C", zones + 16, 2);
+    print_readings("D", zones + 18, 8);
+    print_readings("E", zones + 26, 8);
 }
 
 static void handle_whoami()

--- a/firmware/src/touch.c
+++ b/firmware/src/touch.c
@@ -156,10 +156,13 @@ bool touch_sensor_ok(unsigned i)
 const uint16_t *touch_raw()
 {
     static uint16_t readout[36] = {0};
+    // Do not use readout as buffer directly, update readout with buffer when operation finishes
+    uint16_t buf[36] = {0};
 
     for (int i = 0; i < 3; i++) {
-        sensor_ok[i] = mpr121_raw(MPR121_BASE_ADDR + i, readout + i * 12, 12);
+        sensor_ok[i] = mpr121_raw(MPR121_BASE_ADDR + i, buf + i * 12, 12);
     }
+    memcpy(readout, buf, sizeof(readout));
 
     return readout;
 }

--- a/firmware/src/touch.c
+++ b/firmware/src/touch.c
@@ -155,16 +155,12 @@ bool touch_sensor_ok(unsigned i)
 
 const uint16_t *touch_raw()
 {
-    static uint16_t readout[36];
-    uint16_t buf[36];
+    static uint16_t readout[36] = {0};
 
     for (int i = 0; i < 3; i++) {
-        sensor_ok[i] = mpr121_raw(MPR121_BASE_ADDR + i, buf + i * 12, 12);
+        sensor_ok[i] = mpr121_raw(MPR121_BASE_ADDR + i, readout + i * 12, 12);
     }
 
-    for (int i = 0; i < 34; i++) {
-        readout[touch_map[i]] = buf[i];
-    }
     return readout;
 }
 

--- a/firmware/src/touch.c
+++ b/firmware/src/touch.c
@@ -167,7 +167,7 @@ const uint16_t *touch_raw()
     return readout;
 }
 
-const uint16_t *map_raw_to_zones(const uint16_t* raw) {
+const uint16_t *map_raw_to_zones(uint16_t* raw) {
     static uint16_t zones[36];
 
     for (int i = 0; i < 34; i++) {

--- a/firmware/src/touch.c
+++ b/firmware/src/touch.c
@@ -167,6 +167,16 @@ const uint16_t *touch_raw()
     return readout;
 }
 
+const uint16_t *map_raw_to_zones(const uint16_t* raw) {
+    static uint16_t zones[36];
+
+    for (int i = 0; i < 34; i++) {
+        zones[touch_map[i]] = raw[i];
+    }
+    
+    return zones;
+}
+
 bool touch_touched(unsigned key)
 {
     if (key >= 34) {

--- a/firmware/src/touch.h
+++ b/firmware/src/touch.h
@@ -29,7 +29,7 @@ uint64_t touch_touchmap();
 void touch_set_map(unsigned sensor, unsigned key);
 
 const uint16_t *touch_raw();
-const uint16_t *map_raw_to_zones(const uint16_t *raw);
+const uint16_t *map_raw_to_zones(uint16_t *raw);
 bool touch_sensor_ok(unsigned i);
 
 void touch_update_config();

--- a/firmware/src/touch.h
+++ b/firmware/src/touch.h
@@ -29,6 +29,7 @@ uint64_t touch_touchmap();
 void touch_set_map(unsigned sensor, unsigned key);
 
 const uint16_t *touch_raw();
+const uint16_t *map_raw_to_zones(const uint16_t *raw);
 bool touch_sensor_ok(unsigned i);
 
 void touch_update_config();


### PR DESCRIPTION
This PR modified the raw command. Now raw command prints out readings separated by sensors & zones. This helps DIY players to examine MPR121 chip failures more efficiently.

![image](https://github.com/user-attachments/assets/cf2cc1f3-a0c7-4c2a-a738-325fba9fd2ee)

