### PR TITLE
Fix error on cp command when building under Windows

### DIFF
--- a/firmware/src/CMakeLists.txt
+++ b/firmware/src/CMakeLists.txt
@@ -26,7 +26,8 @@ function(make_firmware board board_def)
     COMMAND touch ${CMAKE_CURRENT_SOURCE_DIR}/cli.c)
 
     add_custom_command(TARGET ${board} POST_BUILD
-                       COMMAND cp ${board}.uf2 ${CMAKE_CURRENT_LIST_DIR}/..)
+                       COMMAND ${CMAKE_COMMAND}
+                       ARGS -E copy ${board}.uf2 ${CMAKE_CURRENT_LIST_DIR}/..)
 endfunction()
 
 make_firmware(mai_pico BOARD_MAI_PICO)


### PR DESCRIPTION
By using cmake [builtin commands](https://cmake.org/cmake/help/book/mastering-cmake/chapter/Custom%20Commands.html) for file operations, this PR should the error at the end of the build process when building under Windows (since Windows doesn't have `cp` command).