### PR TITLE
Fix sense

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ Production/PCB/*/
 *-backups
 .editorconfig
 .vscode
-
+build/
+firmware/mai_pico.uf2

--- a/firmware/src/commands.c
+++ b/firmware/src/commands.c
@@ -19,7 +19,7 @@
 #include "aime.h"
 #include "nfc.h"
 
-#define SENSE_LIMIT_MAX 20
+#define SENSE_LIMIT_MAX 127
 #define SENSE_LIMIT_MIN -128
 
 static void disp_rgb()

--- a/firmware/src/config.c
+++ b/firmware/src/config.c
@@ -78,12 +78,12 @@ static void config_loaded()
         mai_cfg->sense = default_cfg.sense;
         config_changed();
     }
-    if (!in_range(mai_cfg->sense.global, -9, 9)) {
+    if (!in_range(mai_cfg->sense.global, -128, 127)) {
         mai_cfg->sense = default_cfg.sense;
         config_changed();
     }
     for (int i = 0; i < 34; i++) {
-        if (!in_range(mai_cfg->sense.zones[i], -9, 9)) {
+        if (!in_range(mai_cfg->sense.zones[i], -128, 127)) {
             mai_cfg->sense = default_cfg.sense;
             config_changed();
             break;

--- a/firmware/src/mpr121.c
+++ b/firmware/src/mpr121.c
@@ -202,7 +202,10 @@ void mpr121_sense(uint8_t addr, int8_t sense, int8_t *sense_keys, int num) {
 
     // Calculate the touch and release thresholds
     uint8_t touch_threshold = TOUCH_THRESHOLD_BASE - delta;
-    uint8_t release_threshold = (RELEASE_THRESHOLD_BASE - delta) / 2;
+    uint8_t release_threshold = RELEASE_THRESHOLD_BASE - (delta / 2);
+    if(release_threshold > touch_threshold) {
+        release_threshold = touch_threshold/2;
+    }
 
     write_reg(addr, MPR121_TOUCH_THRESHOLD_REG + i * 2, touch_threshold);
     write_reg(addr, MPR121_RELEASE_THRESHOLD_REG + i * 2, release_threshold);

--- a/firmware/src/touch.c
+++ b/firmware/src/touch.c
@@ -182,6 +182,15 @@ const uint16_t *map_raw_to_zones(const uint16_t* raw)
     return zones;
 }
 
+const int8_t *unmap_sense_to_raw(const int8_t* memsense)
+{
+    static int8_t outsense[36];
+    for(int i = 0; i < 34; i++) {
+        outsense[i] = memsense[touch_map[i]];
+    }
+    return outsense;
+}
+
 bool touch_touched(unsigned key)
 {
     if (key >= 34) {
@@ -210,13 +219,14 @@ void touch_reset_stat()
 
 void touch_update_config()
 {
+    const int8_t* outsense = unmap_sense_to_raw((const int8_t*)mai_cfg->sense.zones);
     for (int m = 0; m < 3; m++) {
         mpr121_debounce(MPR121_BASE_ADDR + m,
                         mai_cfg->sense.debounce_touch,
                         mai_cfg->sense.debounce_release);
         mpr121_sense(MPR121_BASE_ADDR + m,
                      mai_cfg->sense.global,
-                     mai_cfg->sense.zones + m * 12,
+                     (int8_t*)outsense + m * 12,
                      m != 2 ? 12 : 10);
         mpr121_filter(MPR121_BASE_ADDR + m,
                       mai_cfg->sense.filter >> 6,


### PR DESCRIPTION
Sensitivity per-sensor settings were broken as they were pushed directly to the MPR121s without going through the reverse map process. Adjusted sensitivity limits and made the command easier to work with.

Did not upload a new uf2 file